### PR TITLE
Make sure plugins are initialized

### DIFF
--- a/plugin_loader/loader.py
+++ b/plugin_loader/loader.py
@@ -29,7 +29,7 @@ class Loader:
                 spec = spec_from_file_location("_", path.join(self.plugin_path, file))
                 module = module_from_spec(spec)
                 spec.loader.exec_module(module)
-                dc[module.Plugin.name] = module.Plugin
+                dc[module.Plugin.name] = module.Plugin()
                 self.logger.info("Loaded {}".format(module.Plugin.name))
             except Exception as e:
                 self.logger.error("Could not load {}. {}".format(file, e))


### PR DESCRIPTION
This was one of the changes that I had to do in order to get the plugins working for me. Without this change, both the ExtraSettings and my music plugin were failing with errors similar to this one on the web console: 

```
Music:127 Uncaught (in promise) Plugin.get_player() missing 1 required positional argument: 'self'
```