### PR TITLE
Added support for including styles/scripts in the header of html files

### DIFF
--- a/plugin_loader/loader.py
+++ b/plugin_loader/loader.py
@@ -69,6 +69,7 @@ class Loader:
             web.get("/plugins/reload", self.reload_plugins),
             web.post("/plugins/method_call", self.handle_plugin_method_call),
             web.get("/plugins/load_main/{name}", self.load_plugin_main_view),
+            web.get("/plugins/src/{name}/{path:.+}", self.handle_sub_route),
             web.get("/plugins/load_tile/{name}", self.load_plugin_tile_view),
             web.get("/steam_resource/{path:.+}", self.get_steam_resource)
         ])
@@ -138,9 +139,23 @@ class Loader:
             ret = """
             <script src="/static/library.js"></script>
             <script>const plugin_name = '{}' </script>
+            <base href="http://127.0.0.1:1337/plugins/src/{}/">
             {}
-            """.format(plugin.name, template_data)
+            """.format(plugin.name, plugin.name, template_data)
             return web.Response(text=ret, content_type="text/html")
+
+    async def handle_sub_route(self, request):
+        plugin = self.plugins[request.match_info["name"]]
+        route_path = request.match_info["path"]
+        self.logger.info(path)
+
+        ret = ""
+
+        file_path = path.join(self.plugin_path, plugin._plugin_directory, route_path)
+        with open(file_path, 'r') as resource_data:
+            ret = resource_data.read()
+
+        return web.Response(text=ret)
 
     async def load_plugin_tile_view(self, request):
         plugin = self.plugins[request.match_info["name"]]


### PR DESCRIPTION
Added support for including styles/scripts in the header of html files. See example below
![image](https://user-images.githubusercontent.com/4239808/162081874-35e55fef-1c76-4c8b-b1cd-c8e4dd6afbb3.png)

**New Directory Structure**
![image](https://user-images.githubusercontent.com/4239808/162080792-9a608b0f-575f-4ce7-bb6b-479ca55a1c48.png)

**index.html**
```html
<html>
  <head>
    <link rel="stylesheet" href="/steam_resource/css/2.css">
    <link rel="stylesheet" href="/steam_resource/css/39.css">
    <link rel="stylesheet" href="/steam_resource/css/library.css">
    <link rel="stylesheet" href="src/style.css"></link>
    <script src="src/index.js"></script>
  </head>
  <body><h2>It Works!</h2></body>
</html>
```

**src/index.js**
```javascript
console.log('test!');
```

**src/style.css**
```css
body, h2 {
  color: red;
}
```