### PR TITLE
remove body property in args

### DIFF
--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -164,7 +164,7 @@ class PluginLoader extends Logger {
         return response.json();
       },
       fetchNoCors(url: string, request: any = {}) {
-        let args = { method: 'POST', headers: {}, body: '' };
+        let args = { method: 'POST', headers: {} };
         const req = { ...args, ...request, url, data: request.body };
         return this.callServerMethod('http_request', req);
       },


### PR DESCRIPTION
`body` is being added a property  in the `args` object; however, the request method of aiohttp's ClientSession does not have an argument for `body`. I think the intention was that `body` is meant to be assigned to `data` which already is happening.