### PR TITLE
feat: expanded plugin unzipping

### DIFF
--- a/backend/src/browser.py
+++ b/backend/src/browser.py
@@ -9,7 +9,7 @@ from asyncio import sleep
 from hashlib import sha256
 from io import BytesIO
 from logging import getLogger
-from os import R_OK, W_OK, path, listdir, access, mkdir
+from os import R_OK, W_OK, path, listdir, access, mkdir, path
 from shutil import rmtree
 from time import time
 from zipfile import ZipFile
@@ -57,7 +57,15 @@ class PluginBrowser:
         if hash and (zip_hash != hash):
             return False
         zip_file = ZipFile(zip)
-        zip_file.extractall(self.plugin_path)
+
+        files = zip_file.namelist()
+        if "plugin.json" in files:
+            zip_file.extractall(path.join(self.plugin_path, name))
+        if name in files:
+            zip_file.extractall(self.plugin_path)
+        if name + ".zip" in files:
+            return self._unzip_to_plugin_dir(BytesIO(zip_file.read(name + ".zip")), name, hash)
+        
         plugin_folder = self.find_plugin_folder(name)
         assert plugin_folder is not None
         plugin_dir = path.join(self.plugin_path, plugin_folder)


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [ ] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

# Description
Current unzipping takes into account only a single structure of zip file in which the plugin is contained within a subfolder of the same name under the zip. This expands this to include both nested zipfiles (uploading artifacts from GHA) as well as the plugin within the root directory of the zip.

In particular this stops having to do this just to be able to publish a zip file through the Artifacts:
https://github.com/CEbbinghaus/MicroSDeck/blob/6f3e010ec8e8f6b6d2e7a293541754a6215ccdef/.github/workflows/build.yml#L37-L47
