### PR TITLE
Fix settings import under windows

### DIFF
--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -14,7 +14,7 @@ from ..localplatform.localsocket import LocalSocket
 from ..localplatform.localplatform import setgid, setuid, get_username, get_home_path, ON_LINUX
 from ..enums import UserType
 from .. import helpers
-from .. import settings
+from .. import settings # pyright: ignore [reportUnusedImport]
 
 from typing import List, TypeVar, Any
 


### PR DESCRIPTION
Please tick as appropriate:
- [X] I have tested this code on a steam deck or on a PC
- [X] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This fixes issue: The settings import for some reason does not get picked up by pyinstaller running under windows, but does when running under linux. This PR adds an explicit import for the settings module to resolve this issue.

Effectively, plugins like tabmaster and steamgriddb (that use the settings api) will now work again under windows.