### PR TITLE
Add `key` prop inside `map` 

### DIFF
--- a/frontend/src/components/settings/pages/testing/index.tsx
+++ b/frontend/src/components/settings/pages/testing/index.tsx
@@ -79,7 +79,7 @@ export default function TestingVersionList() {
         <ul style={{ listStyleType: 'none', padding: '0' }}>
           {testingVersions.map((version) => {
             return (
-              <li>
+              <li key={`${version.id}_${version.name}`}>
                 <Field
                   label={
                     <>

--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -240,6 +240,7 @@ const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }>
             })
             .map((plugin: StorePlugin) => (
               <PluginCard
+                key={`${plugin.id}_${plugin.name}`}
                 storePlugin={plugin}
                 installedPlugin={installedPlugins.find((installedPlugin) => installedPlugin.name === plugin.name)}
               />


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This PR added missed `key` prop inside  `map`. By adding `key` to elements, React can better detect which elements should be shown / removed from UI.

This fixes issue: #866

Please provide a clear and concise description of what the new feature is. If appropriate, include screenshots or videos.
