### PR TITLE
Return 404 instead of 500 when plugin not loaded in HTTP handlers

### DIFF
--- a/backend/decky_loader/loader.py
+++ b/backend/decky_loader/loader.py
@@ -134,26 +134,38 @@ class Loader:
         return [{"name": str(i), "version": i.version, "load_type": i.load_type, "disabled": i.disabled} for i in plugins]
 
     async def handle_plugin_dist(self, request: web.Request):
-        plugin = self.plugins[request.match_info["plugin_name"]]
+        plugin_name = request.match_info["plugin_name"]
+        if plugin_name not in self.plugins:
+            return web.Response(status=404, text=f"Plugin {plugin_name} not found")
+        plugin = self.plugins[plugin_name]
         file = path.join(self.plugin_path, plugin.plugin_directory, "dist", request.match_info["path"])
 
         return web.FileResponse(file, headers={"Cache-Control": "no-cache"})
 
     async def handle_plugin_frontend_assets(self, request: web.Request):
-        plugin = self.plugins[request.match_info["plugin_name"]]
+        plugin_name = request.match_info["plugin_name"]
+        if plugin_name not in self.plugins:
+            return web.Response(status=404, text=f"Plugin {plugin_name} not found")
+        plugin = self.plugins[plugin_name]
         file = path.join(self.plugin_path, plugin.plugin_directory, "dist/assets", request.match_info["path"])
 
         return web.FileResponse(file, headers={"Cache-Control": "no-cache"})
 
     async def handle_plugin_frontend_assets_from_data(self, request: web.Request):
-        plugin = self.plugins[request.match_info["plugin_name"]]
+        plugin_name = request.match_info["plugin_name"]
+        if plugin_name not in self.plugins:
+            return web.Response(status=404, text=f"Plugin {plugin_name} not found")
+        plugin = self.plugins[plugin_name]
         home = get_homebrew_path()
         file = path.join(home, "data", plugin.plugin_directory, request.match_info["path"])
 
         return web.FileResponse(file, headers={"Cache-Control": "no-cache"})
 
     async def handle_frontend_bundle(self, request: web.Request):
-        plugin = self.plugins[request.match_info["plugin_name"]]
+        plugin_name = request.match_info["plugin_name"]
+        if plugin_name not in self.plugins:
+            return web.Response(status=404, text=f"Plugin {plugin_name} not found")
+        plugin = self.plugins[plugin_name]
 
         with open(path.join(self.plugin_path, plugin.plugin_directory, "dist/index.js"), "r", encoding="utf-8") as bundle:
             return web.Response(text=bundle.read(), content_type="application/javascript")


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This fixes issue: potential unhandled `KeyError` crashes in the HTTP route handlers that serve plugin assets.

The four handlers — `handle_plugin_dist`, `handle_plugin_frontend_assets`, `handle_plugin_frontend_assets_from_data`, and `handle_frontend_bundle` — all access `self.plugins[request.match_info["plugin_name"]]` directly without checking whether the plugin is actually present in the dict. If the frontend happens to request assets for a plugin that has crashed, been uninstalled, or is mid-reload, this raises an unhandled `KeyError` and aiohttp returns a 500 with a stack trace rather than a clean error the frontend could handle gracefully.

This adds a simple guard to each of the four handlers: if the requested plugin name isn't in `self.plugins`, return a 404 instead of letting the KeyError propagate. The change only affects the already-broken case where assets are requested for a plugin that isn't loaded — normal behavior is completely unchanged.

**Honest disclaimers:** I haven't been able to test this on a Steam Deck (I don't have one set up for development at the moment), so I'm going off of reading the code. The change is intentionally minimal and defensive — it's just a dict membership check before the lookup. That said, if there's a reason these handlers were left without the check (e.g. the frontend is expected to never hit these routes for unloaded plugins and a 500 is preferred as a signal), happy to hear that and close this out. Just seemed like it could help with stability in edge cases.