### PR TITLE
Add missing key prop to PluginCard in store listing

### DIFF
--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -240,6 +240,7 @@ const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }>
             })
             .map((plugin: StorePlugin) => (
               <PluginCard
+                key={plugin.id}
                 storePlugin={plugin}
                 installedPlugin={installedPlugins.find((installedPlugin) => installedPlugin.name === plugin.name)}
               />


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This fixes issue: #866

When rendering the plugin list in the store, `<PluginCard>` components are rendered inside `.map()` without a `key` prop. Without it, React reuses component instances by their position in the list rather than by identity. When the user changes the sort order, internal component state (like the selected version in the dropdown) carries over from whatever plugin previously occupied that list position, causing stale/incorrect version info to be displayed.

The fix adds `key={plugin.id}` to the `<PluginCard>` element so React correctly re-mounts components when the list order changes.

**Note:** I haven't been able to test this on a Steam Deck, but the change is a standard React list-rendering fix — lint, typecheck, and build all pass cleanly.