### PR TITLE
Disable live reload by default

### DIFF
--- a/backend/decky_loader/localplatform/localplatform.py
+++ b/backend/decky_loader/localplatform/localplatform.py
@@ -32,7 +32,7 @@ def get_server_port() -> int:
     return int(os.getenv("SERVER_PORT", "1337"))
 
 def get_live_reload() -> bool:
-    return os.getenv("LIVE_RELOAD", "1") == "1"
+    return os.getenv("LIVE_RELOAD", "0") == "1"
 
 def get_keep_systemd_service() -> bool:
     return os.getenv("KEEP_SYSTEMD_SERVICE", "0") == "1"


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This fixes issue: #851

The `LIVE_RELOAD` environment variable defaults to `"1"` (enabled), which means the watchdog file observer is always active — even for regular users who aren't developing plugins. For plugins with large dependency trees, this causes a flood of inotify events during startup that can race with plugin loading and cause load failures.

The fix changes the default from `"1"` to `"0"`. Developers who need live reload can still enable it by setting `LIVE_RELOAD=1`. The `Loader.__init__` constructor already defaults to `live_reload=False`, which suggests disabled was the intended default.

As noted in the issue, the reporter confirmed that manually disabling live reload via a systemd override resolved their plugin loading failures entirely.

I haven't tested this on a Steam Deck myself, but the change is a single-character default swap with no behavioral impact for anyone who already sets the env var explicitly.