### PR TITLE
Use non-zero exit code when plugin fails to start

### DIFF
--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -126,7 +126,7 @@ class SandboxedPlugin:
             get_event_loop().create_task(socket.setup_server(self.on_new_message))
         except:
             self.log.error("Failed to start " + self.name + "!\n" + format_exc())
-            sys.exit(0)
+            sys.exit(1)
         try:
             get_event_loop().run_forever()
         except SystemExit:


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

In `sandboxed_plugin.py`, when a plugin raises an exception during initialization, the except block calls `sys.exit(0)`. Since exit code 0 conventionally means success, this masks the failure — any process monitoring or logging that checks exit codes would incorrectly conclude the plugin started fine.

This changes it to `sys.exit(1)` so the exit code correctly reflects that the plugin failed to start. The `sys.exit(0)` in the `shutdown()` method (clean shutdown path) is left as-is, since that's the expected success case.

Single-character change, pyright passes cleanly. I don't have a Steam Deck to test on, but the behavioral change is limited to the process exit code on an already-failing path — it won't affect any plugin that starts successfully.