### PR TITLE
Replace bare except clauses with except Exception

### DIFF
--- a/backend/decky_loader/browser.py
+++ b/backend/decky_loader/browser.py
@@ -114,7 +114,7 @@ class PluginBrowser:
 
                 if plugin['name'] == name:
                     return folder
-            except:
+            except Exception:
                 logger.debug(f"skipping {folder}")
     
     def set_plugin_dir_permissions(self, plugin_dir: str) -> bool:
@@ -182,7 +182,7 @@ class PluginBrowser:
             pluginFolderPath = self.find_plugin_folder(name)
             if pluginFolderPath:
                 isInstalled = True
-        except:
+        except Exception:
             logger.error(f"Failed to determine if {name} is already installed, continuing anyway.")
 
         # Preserve plugin order before removing plugin (uninstall alters the order and removes the plugin from the list)
@@ -264,7 +264,7 @@ class PluginBrowser:
             try:
                 logger.debug("Uninstalling existing plugin...")
                 await self.uninstall_plugin(name)
-            except:
+            except Exception:
                 logger.error(f"Plugin {name} could not be uninstalled.")
 
 

--- a/backend/decky_loader/localplatform/localplatformlinux.py
+++ b/backend/decky_loader/localplatform/localplatformlinux.py
@@ -80,7 +80,7 @@ def chmod(path : str, permissions : int, recursive : bool = True) -> bool:
                     os.chmod(os.path.join(root, d), octal_permissions)
 
         os.chmod(path, octal_permissions)
-    except:
+    except Exception:
         return False
 
     return True

--- a/backend/decky_loader/localplatform/localsocket.py
+++ b/backend/decky_loader/localplatform/localsocket.py
@@ -37,7 +37,7 @@ class UnixSocket:
                 try:
                     self.reader, self.writer = await asyncio.open_unix_connection(self.socket_addr, limit=BUFFER_LIMIT)
                     return True
-                except:
+                except Exception:
                     await asyncio.sleep(2)
                     retries += 1
             return False
@@ -151,7 +151,7 @@ class PortSocket (UnixSocket):
                 try:
                     self.reader, self.writer = await asyncio.open_connection(host=self.host, port=self.port, limit=BUFFER_LIMIT)
                     return True
-                except:
+                except Exception:
                     await asyncio.sleep(2)
                     retries += 1
             return False

--- a/backend/decky_loader/main.py
+++ b/backend/decky_loader/main.py
@@ -130,7 +130,7 @@ class PluginManager:
             if self.js_ctx_tab:
                 await self.js_ctx_tab.close_websocket()
                 self.js_ctx_tab = None
-        except:
+        except Exception:
             logger.info("Error during shutdown:\n" + format_exc())
             pass
         finally:
@@ -147,7 +147,7 @@ class PluginManager:
                     except CancelledError:
                         pass
                     logger.debug(f"Task {name} finished")
-                except:
+                except Exception:
                     logger.warning(f"Failed to cancel task {name}:\n" + format_exc())
                     pass
             if current:
@@ -244,7 +244,7 @@ class PluginManager:
                 self.reinject = False
                 await sleep(1)
                 await self.updater.do_shutdown()
-        except:
+        except Exception:
             logger.info("Failed to inject JavaScript into tab\n" + format_exc())
             pass
 

--- a/backend/decky_loader/plugin/plugin.py
+++ b/backend/decky_loader/plugin/plugin.py
@@ -95,7 +95,7 @@ class PluginWrapper:
                 self.log.info(f"Stopping response listener for {self.name}")
                 await self._socket.close_socket_connection()
                 raise
-            except:
+            except Exception:
                 pass
 
     async def execute_legacy_method(self, method_name: str, kwargs: Dict[Any, Any]):

--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -124,14 +124,14 @@ class SandboxedPlugin:
                 else:
                     get_event_loop().create_task(self.Plugin._main(self.Plugin))
             get_event_loop().create_task(socket.setup_server(self.on_new_message))
-        except:
+        except Exception:
             self.log.error("Failed to start " + self.name + "!\n" + format_exc())
             sys.exit(0)
         try:
             get_event_loop().run_forever()
         except SystemExit:
             pass
-        except:
+        except Exception:
             self.log.error("Loop exited for " + self.name + "!\n" + format_exc())
         finally:
             get_event_loop().close()
@@ -147,7 +147,7 @@ class SandboxedPlugin:
                 self.log.info("Unloaded " + self.name + "\n")
             else:
                 self.log.info("Could not find \"_unload\" in " + self.name + "'s main.py" + "\n")
-        except:
+        except Exception:
             self.log.error("Failed to unload " + self.name + "!\n" + format_exc())
             pass
 
@@ -162,7 +162,7 @@ class SandboxedPlugin:
                 self.log.info("Uninstalled " + self.name + "\n")
             else:
                 self.log.info("Could not find \"_uninstall\" in " + self.name + "'s main.py" + "\n")
-        except:
+        except Exception:
             self.log.error("Failed to uninstall " + self.name + "!\n" + format_exc())
             pass
 

--- a/backend/decky_loader/updater.py
+++ b/backend/decky_loader/updater.py
@@ -45,7 +45,7 @@ class Updater:
 
         try:
             self.currentBranch = self.get_branch(self.context.settings)
-        except:
+        except Exception:
             self.currentBranch = 0
             logger.error("Current branch could not be determined, defaulting to \"Stable\"")
 
@@ -134,7 +134,7 @@ class Updater:
         while True:
             try:
                 await self.check_for_updates()
-            except:
+            except Exception:
                 pass
             await sleep(60 * 60 * 6) # 6 hours
 

--- a/backend/decky_loader/wsrouter.py
+++ b/backend/decky_loader/wsrouter.py
@@ -68,7 +68,7 @@ class WSRouter:
         if instance_id != self.instance_id:
             try:
                 self.logger.warning("Ignoring %s reply from stale instance %d with args %s and response %s", route, instance_id, args, res)
-            except:
+            except Exception:
                 self.logger.warning("Ignoring %s reply from stale instance %d (failed to log event data)", route, instance_id)
             finally:
                 return 
@@ -91,7 +91,7 @@ class WSRouter:
         if self.ws != None:
             try:
                 await self.ws.close()
-            except:
+            except Exception:
                 pass
             self.ws = None
 
@@ -122,7 +122,7 @@ class WSRouter:
             try:
                 await ws.close()
                 self.ws = None
-            except:
+            except Exception:
                 pass
 
         self.logger.debug('Websocket connection closed')


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

There are 19 bare `except:` clauses across 8 files in the backend. Bare `except:` catches everything including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which are generally not intended to be caught in application-level error handling.

This replaces all of them with `except Exception:`, which preserves the existing behavior for normal exceptions while letting interpreter-level exceptions propagate correctly. PEP 8 [recommends this](https://peps.python.org/pep-0008/#programming-recommendations) as the standard practice.

**Practical impact:** The most noticeable difference is in retry loops (like `localsocket.py` and `updater.py`'s `version_reloader`) where a bare `except:` would catch `KeyboardInterrupt`, making Ctrl+C unresponsive during development/debugging. With `except Exception:`, those signal-based exceptions will propagate as expected.

The change is purely mechanical — every `except:` becomes `except Exception:`, no logic changes. Pyright passes with no new errors. I don't have a Steam Deck to test on, but since the narrowing only affects exception types that shouldn't be caught in normal operation (`SystemExit`, `KeyboardInterrupt`, `GeneratorExit`), the risk of behavioral change in production is minimal.

Where `SystemExit` does need to be handled, the codebase already catches it explicitly (e.g. `sandboxed_plugin.py` line 132), which is the right approach.

**Files changed:**
- `browser.py` (3 instances)
- `localsocket.py` (2 instances)
- `localplatformlinux.py` (1 instance)
- `main.py` (3 instances)
- `plugin.py` (1 instance)
- `sandboxed_plugin.py` (4 instances)
- `updater.py` (2 instances)
- `wsrouter.py` (3 instances)

Happy to adjust or split this up if you'd prefer individual changes per file.