### PR TITLE
Remove incorrect padding in the decky menu

### DIFF
--- a/frontend/src/components/TitleView.tsx
+++ b/frontend/src/components/TitleView.tsx
@@ -8,7 +8,6 @@ import { useDeckyState } from './DeckyState';
 
 const titleStyles: CSSProperties = {
   display: 'flex',
-  paddingTop: '3px',
   paddingRight: '16px',
   position: 'sticky',
   top: '0px',


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

fix decky menu being 3px lower than valve menus lol