### PR TITLE
fix(toaster): Forward playSound prop to ProcessNotification info

### DIFF
--- a/frontend/src/toaster.tsx
+++ b/frontend/src/toaster.tsx
@@ -81,6 +81,7 @@ class Toaster extends Logger {
     const info = {
       showToast: toast.showToast,
       sound: toast.sound,
+      playSound: toast.playSound,
       eFeature: 0,
       toastDurationMS: toastData.nToastDurationMS,
       bCritical: toast.critical,


### PR DESCRIPTION
## Problem

The `toast()` method accepts `playSound` and defaults it to `true`, but the `info` object passed to `NotificationStore.ProcessNotification()` never includes it. Steam's `ChooseSound` logic does:

```js
const play = e.playSound ?? !!e.sound;
```

Without `playSound` in the info object, it falls back to `!!e.sound`, which is always truthy for the default sound type (`eType: 31`). Setting `playSound: false` in a plugin's toast call has no effect.

## Fix

Forward `toast.playSound` in the `info` object so Steam's `ChooseSound` uses the explicit value.

## Workaround this replaces

I was able to work around this by using `eType: 40` and `sound: 0` to silence toasts, as documented in [this gist](https://gist.github.com/mdeguzis/7bef2731edd67a6dea06ffc622a1bae6).

## Testing

- TypeScript typecheck passes (`tsc --noEmit`)
- Rollup build succeeds
- The `@decky/api` `ToastData` interface already declares `playSound?: boolean`, so no type changes needed